### PR TITLE
feat: показывать распределение студентов по наставникам до начала уроков

### DIFF
--- a/bot/handlers/gradebook.py
+++ b/bot/handlers/gradebook.py
@@ -580,17 +580,25 @@ async def _render_admin_list(message: types.Message, session, training_id: Optio
     for m in mentors:
         summary = await build_mentor_overview(session, mentor_id=m.id, training_id=training_id, lesson_id=lesson_id, include_not_started=False)
         students = summary.get("students", {})
-        per_student = {}
+
+        # Инициализируем счетчики для всех студентов нулевыми значениями
+        per_student = {
+            sid: {
+                STATUS_HAS_ANSWER: 0,
+                STATUS_NO_ANSWER: 0,
+            }
+            for sid in students.keys()
+        }
+
+        # Обновляем счетчики из items (активные/завершенные уроки)
         for it in summary.get("items", []):
             sid = it.get("student_id") if isinstance(it, dict) else it.student_id
             st = it.get("status") if isinstance(it, dict) else it.status
             simplified_status = simplify_status(st)
             if simplified_status is None:
                 continue  # Пропускаем STATUS_OPTIONAL и другие
-            per_student.setdefault(sid, {
-                STATUS_HAS_ANSWER: 0,
-                STATUS_NO_ANSWER: 0,
-            })[simplified_status] += 1
+            if sid in per_student:  # Проверяем, что студент еще в списке
+                per_student[sid][simplified_status] += 1
         def s_key(sid):
             info = students.get(sid, {})
             return ((info.get("last_name") or "").lower(), (info.get("first_name") or "").lower(), sid)
@@ -609,7 +617,7 @@ async def _render_admin_list(message: types.Message, session, training_id: Optio
         mentor_first = m.first_name or ""
         mentor_full_name = f"{mentor_last} {mentor_first}".strip()
         mentor_name = f"{bold('Наставник')}: {escape_markdown_v2(mentor_full_name)}"
-        if student_rows:  # Добавляем только наставников с назначенными студентами
+        if student_rows:  # Добавляем наставников с назначенными студентами (даже если статистика нулевая)
             blocks.append((mentor_name, student_rows, len(student_rows)))
 
     if not blocks:


### PR DESCRIPTION
Показывать всех студентов наставника в табеле успеваемости даже если уроки еще не начались. Статистика будет нулевой (✅ - 0 | ❌ - 0), но распределение студентов по наставникам будет видно.